### PR TITLE
Added WaitVisible

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ The view will create the following methods for each locator object:
   * msg {String} optional. Message to accompany error in failure case
 * returns: Promise which resolves to true or false
 
-##### [locatorName]WaitAndClick
+##### [locatorName]WaitForVisibleAndClick
 
 * arguments
   * timeout {Number} time to wait in milliseconds

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ The view will create the following methods for each locator object:
   * msg {String} optional. Message to accompany error in failure case
 * returns: Promise which resolves to true or false
 
-##### [locatorName]WaitForVisible
+##### [locatorName]WaitVisible
 
 * arguments
   * timeout {Number} time to wait in milliseconds

--- a/README.md
+++ b/README.md
@@ -367,12 +367,12 @@ The view will create the following methods for each locator object:
   * msg {String} optional. Message to accompany error in failure case
 * returns: Promise which resolves to true or false
 
-##### [locatorName]WaitForVisibleAndClick
+##### [locatorName]WaitForVisible
 
 * arguments
   * timeout {Number} time to wait in milliseconds
   * msg {String} optional. Message to accompany error in failure case
-* returns: A promise that will be resolved when the click command has completed.
+* returns: A promise that will be resolved when element is found.
 
 ##### [locatorName]Visible
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,13 @@ The view will create the following methods for each locator object:
   * msg {String} optional. Message to accompany error in failure case
 * returns: Promise which resolves to true or false
 
+##### [locatorName]WaitAndClick
+
+* arguments
+  * timeout {Number} time to wait in milliseconds
+  * msg {String} optional. Message to accompany error in failure case
+* returns: A promise that will be resolved when the click command has completed.
+
 ##### [locatorName]Visible
 
 * arguments: none

--- a/lib/view.js
+++ b/lib/view.js
@@ -88,6 +88,10 @@ var locreator = function(thees, context, loc, _loc, el) {
         context[loc + "Wait"] = (function(timeout, msg) {
             return thees.drivex.waitForElement(_loc, timeout || 5000, msg); //wait(_loc, timeout, msg);
         }).bind(thees);
+        context[loc + "WaitAndClick"] = (function(timeout, msg) {
+            thees.drivex.waitForElement(_loc, timeout || 5000, msg);
+            return thees.drivex.find(_loc).click();
+        }).bind(thees);
         context[loc + "Visible"] = (function() {
             return thees.drivex.visible(_loc, el);
         }).bind(thees);

--- a/lib/view.js
+++ b/lib/view.js
@@ -89,13 +89,13 @@ var locreator = function(thees, context, loc, _loc, el) {
         context[loc + "Wait"] = (function(timeout, msg) {
             return thees.drivex.waitForElement(_loc, timeout || 5000, msg); //wait(_loc, timeout, msg);
         }).bind(thees);
-        context[loc + "WaitForVisibleAndClick"] = (function (timeout, msg) {
+        context[loc + "WaitForVisible"] = (function (timeout, msg) {
             thees.driver.wait(function () {
                 return thees.drivex.visible(_loc).then(function (isVisible) {
                     return isVisible;
                 });
             }, timeout || 5000, msg);
-            return thees.drivex.find(_loc).click();
+            return thees.drivex.find(_loc);
         }).bind(thees);
         context[loc + "Visible"] = (function() {
             return thees.drivex.visible(_loc, el);

--- a/lib/view.js
+++ b/lib/view.js
@@ -91,7 +91,7 @@ var locreator = function(thees, context, loc, _loc, el) {
         }).bind(thees);
         context[loc + "WaitForVisibleAndClick"] = (function (timeout, msg) {
             thees.driver.wait(function () {
-                return thees.drivex.present(_loc).then(function (isVisible) {
+                return thees.drivex.visible(_loc).then(function (isVisible) {
                     return isVisible;
                 });
             }, timeout || 5000, msg);

--- a/lib/view.js
+++ b/lib/view.js
@@ -35,6 +35,7 @@ ViewInterface.prototype.init = function(context, nemo) {
         locator = resolveLocator(context.config, nemo),
         viewName = resolveViewName(context.config),
         that = this;
+    this.driver = nemo.driver;
     this.drivex = drivex;
     this.wd = nemo.wd;
     nemo.locator[viewName] = locator;
@@ -88,8 +89,12 @@ var locreator = function(thees, context, loc, _loc, el) {
         context[loc + "Wait"] = (function(timeout, msg) {
             return thees.drivex.waitForElement(_loc, timeout || 5000, msg); //wait(_loc, timeout, msg);
         }).bind(thees);
-        context[loc + "WaitAndClick"] = (function(timeout, msg) {
-            thees.drivex.waitForElement(_loc, timeout || 5000, msg);
+        context[loc + "WaitForVisibleAndClick"] = (function (timeout, msg) {
+            thees.driver.wait(function () {
+                return thees.drivex.present(_loc).then(function (isVisible) {
+                    return isVisible;
+                });
+            }, timeout || 5000, msg);
             return thees.drivex.find(_loc).click();
         }).bind(thees);
         context[loc + "Visible"] = (function() {

--- a/lib/view.js
+++ b/lib/view.js
@@ -89,7 +89,7 @@ var locreator = function(thees, context, loc, _loc, el) {
         context[loc + "Wait"] = (function(timeout, msg) {
             return thees.drivex.waitForElement(_loc, timeout || 5000, msg); //wait(_loc, timeout, msg);
         }).bind(thees);
-        context[loc + "WaitForVisible"] = (function (timeout, msg) {
+        context[loc + "WaitVisible"] = (function (timeout, msg) {
             thees.driver.wait(function () {
                 return thees.drivex.visible(_loc).then(function (isVisible) {
                     return isVisible;


### PR DESCRIPTION
Wait for an element to be visible and click is always a safer option than just a plain click. Also This way, we can DRY some code like

from 
``` javascript
nemo.driver.wait(function () {
     return nemo.drivex.visible({'locator':'button1','type':'id'}).then(function (isVisible) {
             return isVisible;
     });
}, 5000, button is not present yet);
nemo.drivex.find({'locator':'button1','type':'id'}).click();
```
to 
``` javascript
signup.button1WaitVisible().click();
```
We could add this to drivex plugin as well for people who use drivex over view plugin 