### PR TITLE
Locator normalize refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,31 @@ View Interface for nemo views
 }
 ```
 
+### locatorDefinition
+
+The `locatorDefinition` can either be a JSON object like this:
+
+```
+{
+  "locator": ".myClass",
+  "type": "css"
+}
+```
+
+Where `type` is any of the locator strategies here: http://seleniumhq.github.io/selenium/docs/api/javascript/namespace
+
+Or can be a string like this:
+
+```
+"css:.myClass"
+```
+String of the form `<type>:<locator>`or `<locator>` (where `<type>` will be assumed as css)
+
+
 ### Writing a locator file
 
 The locator JSON file describes elements and the locator strategy used for each one. The most common use case is to store
-all your locator files in the `nemoBaseDir` + /locator directory
+all your locator files in the `nemoBaseDir` + /locator directory. The below example uses the JSON style `locatorDefinition`.
 
 #### textBox.json
 
@@ -208,34 +229,32 @@ The following generic methods are added to `nemo.view`
 
 #### _find(locatorString)
 
-`@argument locatorString {String}` - String of the form `<strategy>:<locator>`or `<locator>` (where `<strategy>` will be assumed as css)
-* `<strategy>` can be any of the valid selenium-webdriver strategies (except JS, not tested): http://seleniumhq.github.io/selenium/docs/api/javascript/namespace_webdriver_By.html
-* `<locator>` a valid locator string matching the chosen `<strategy>`
+`@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
 `@returns {Promise}` resolves to a WebElement or rejected
 
 #### _finds(locatorString)
 
-`@argument locatorString {String}` - see above
+`@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
 `@returns {Promise}` resolves to an array of WebElements or rejected
 
 
 #### _present(locatorString)
 
-`@argument locatorString {String}` - see above
+`@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
 `@returns {Promise}` resolves to true or rejected
 
 #### _visible(locatorString)
 
-`@argument locatorString {String}` - see above
+`@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
 `@returns {Promise}` resolves to true or rejected
 
 #### _wait(locatorString[, timeout])
 
-`@argument locatorString {String}` - see above
+`@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
 `@argument timeout {Integer} (optional, default 5000)` - ms to wait until rejecting
 
@@ -243,7 +262,7 @@ The following generic methods are added to `nemo.view`
 
 #### _waitVisible(locatorString[, timeout])
 
-`@argument locatorString {String}` - see above
+`@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
 `@argument timeout {Integer} (optional, default 5000)` - ms to wait until rejecting
 
@@ -252,7 +271,7 @@ The following generic methods are added to `nemo.view`
 #### _firstVisible(locatorObject[, timeout])
 
 `@argument locatorObject {Object}` - Object of key/value pairs where the key describes the element to find and the
-value is a `locatorString` (see above). Example would be:
+value is a `locatorDefinition` (see above). Example would be:
 ```javascript
 {
   'loginerror': '.notification.notification-critical',

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@
 /* global require: true, module: true */
 "use strict";
 var View = require('./lib/view');
+var util = require('./util');
 var Locreator = require('./lib/locreator');
 var debug = require('debug');
 var log = debug('nemo-view:log');
@@ -53,6 +54,8 @@ function addView(nemo, locreator) {
 }
 module.exports.setup = function (_locatorDirectory, _nemo, __callback) {
   log('plugin setup is called');
+
+  //normalize arguments
   var nemo = _nemo;
   var locatorDirectory = _locatorDirectory;
   var _callback = __callback;
@@ -61,22 +64,18 @@ module.exports.setup = function (_locatorDirectory, _nemo, __callback) {
     nemo = arguments[0];
     _callback = arguments[1];
   }
-  var locreator = new Locreator(nemo);
-  function once(fn) {
-    var called = false;
-    return function (err) {
-      if (!!called) {
-        return undefined;
-      }
-      called = true;
-      return fn(err);
-    };
-  }
+  var callback = util.once(_callback);
 
-  var callback = once(_callback);
+  //add view namespace
   nemo.view = {};
+
+  //instantiate locreator
+  var locreator = new Locreator(nemo);
+
+  //get on with it
   locreator.addGenericMethods(nemo);
   nemo.view.addView = addView(nemo, locreator);
+
   //get all files in the locator directory and sub-directories
   if (locatorDirectory !== null) {
     glob("**/*.json", {cwd: locatorDirectory}, function (err, files) {

--- a/index.js
+++ b/index.js
@@ -15,14 +15,14 @@
 /* global require: true, module: true */
 "use strict";
 var View = require('./lib/view');
-var locreator = require('./lib/locreator');
+var Locreator = require('./lib/locreator');
 var debug = require('debug');
 var log = debug('nemo-view:log');
 var error = debug('nemo-view:error');
 var glob = require("glob");
 var path = require('path');
 
-function addView(nemo) {
+function addView(nemo, locreator) {
 
   return function (json, viewNSArray, hang) {
     log('add view', viewNSArray);
@@ -45,7 +45,7 @@ function addView(nemo) {
     //default hang to true
 
 
-    var _view = View(nemo, json);
+    var _view = View(nemo, locreator, json);
 
     viewNS[viewNSArray[viewNSArray.length - 1]] = _view;
     return _view;
@@ -61,6 +61,7 @@ module.exports.setup = function (_locatorDirectory, _nemo, __callback) {
     nemo = arguments[0];
     _callback = arguments[1];
   }
+  var locreator = new Locreator(nemo);
   function once(fn) {
     var called = false;
     return function (err) {
@@ -75,7 +76,7 @@ module.exports.setup = function (_locatorDirectory, _nemo, __callback) {
   var callback = once(_callback);
   nemo.view = {};
   locreator.addGenericMethods(nemo);
-  nemo.view.addView = addView(nemo);
+  nemo.view.addView = addView(nemo, locreator);
   //get all files in the locator directory and sub-directories
   if (locatorDirectory !== null) {
     glob("**/*.json", {cwd: locatorDirectory}, function (err, files) {

--- a/lib/locreator.js
+++ b/lib/locreator.js
@@ -1,45 +1,55 @@
 'use strict';
 var Drivex = require('selenium-drivex');
+var Locatex = require('./locatex');
 var _ = require('lodash');
 var normalize = require('./normalize');
 
-module.exports.addGenericMethods = function generics(nemo) {
-  var normify = function (locator) {
+var Locreator = function (nemo) {
+  this.nemo = nemo;
+  this.drivex = Drivex(nemo.driver, nemo.wd);
+  this.locatex = Locatex(nemo);
+  this.normify = this.normalize = function (locator) {
     return normalize(nemo, locator);
   };
-  var drivex = Drivex(nemo.driver, nemo.wd);
-
-  nemo.view._find = function (locator) {
-    return drivex.find(normify(locator));
-  };
-  nemo.view._finds = function (locator) {
-    return drivex.finds(normify(locator));
-  };
-  nemo.view._present = function (locator) {
-    return drivex.present(normify(locator));
-  };
-  nemo.view._visible = function (locator) {
-    return drivex.visible(normify(locator));
-  };
-  nemo.view._wait = function (locator, timeout) {
-    return drivex.waitForElementPromise(normify(locator), timeout);
-  };
-  nemo.view._waitVisible = function (locator, timeout) {
-    return drivex.waitForElementVisiblePromise(normify(locator), timeout || 5000);
-  };
-  nemo.view._firstVisible = function (_locatorObject, timeout) {
-    //transform _locatorObject to use native selenium-webdriver Locator format
-    var locatorObject = _.transform(_locatorObject, function(result, n, key) {
-      result[key] = normify(_locatorObject[key]);
-    });
-    return drivex.firstVisible(locatorObject, timeout);
-  };
-
 };
-module.exports.addStarMethods = function locreator(nemo, locatorId, _locator, parentWebElement) {
+
+Locreator.prototype.addGenericMethods = function generics() {
+    var normify = this.normify;
+    var drivex = this.drivex;
+    var nemo = this.nemo;
+
+    nemo.view._find = function (locator) {
+      return drivex.find(normify(locator));
+    };
+    nemo.view._finds = function (locator) {
+      return drivex.finds(normify(locator));
+    };
+    nemo.view._present = function (locator) {
+      return drivex.present(normify(locator));
+    };
+    nemo.view._visible = function (locator) {
+      return drivex.visible(normify(locator));
+    };
+    nemo.view._wait = function (locator, timeout) {
+      return drivex.waitForElementPromise(normify(locator), timeout);
+    };
+    nemo.view._waitVisible = function (locator, timeout) {
+      return drivex.waitForElementVisiblePromise(normify(locator), timeout || 5000);
+    };
+    nemo.view._firstVisible = function (_locatorObject, timeout) {
+      //transform _locatorObject to use native selenium-webdriver Locator format
+      var locatorObject = _.transform(_locatorObject, function(result, n, key) {
+        result[key] = normify(_locatorObject[key]);
+      });
+      return drivex.firstVisible(locatorObject, timeout);
+    };
+
+  };
+
+Locreator.prototype.addStarMethods = function locreator(locatorId, _locator, parentWebElement) {
   var locatorObject = {};
-  var drivex = Drivex(nemo.driver, nemo.wd);
-  var locator = normalize(nemo, _locator);
+  var drivex = this.drivex;
+  var locator = this.normify(_locator);
 
   locatorObject[locatorId] = function () {
     return drivex.find(locator, parentWebElement);
@@ -68,3 +78,24 @@ module.exports.addStarMethods = function locreator(nemo, locatorId, _locator, pa
   return locatorObject;
 };
 
+Locreator.prototype.addGroup = function (viewJSON, locator, locatorId) {
+  var nemo = this.nemo;
+  var drivex = this.drivex;
+  var locatex = this.locatex;
+  var self = this;
+  return function () { //give back the nemo.view.viewname.list() function
+    return drivex.finds(normalize(nemo, locator)).then(function (parentWebElements) {
+      return nemo.wd.promise.map(parentWebElements, function (parentWebElement) {
+        var parentObject = {};
+        Object.keys(viewJSON[locatorId].Elements).forEach(function (childLocatorId) {
+          var childLocator = locatex(viewJSON, [locatorId, 'Elements', childLocatorId]);
+          var starMethods = self.addStarMethods(childLocatorId, childLocator, parentWebElement);
+          _.merge(parentObject, starMethods);
+        });
+        return parentObject;
+      });
+    });
+  };
+};
+
+module.exports = Locreator;

--- a/lib/locreator.js
+++ b/lib/locreator.js
@@ -1,11 +1,16 @@
 'use strict';
 var Drivex = require('selenium-drivex');
 var _ = require('lodash');
-var _by = function (nemo, locator) {
+
+var _normify = function (nemo, _locator) {
+  var locator = _locator;
+  if (_locator.constructor === String) {
+    locator = _splitLocator(_locator);
+  }
   return nemo.wd.By[locator.type](locator.locator);
 };
 
-var splitLocator = function (locatorString) {
+var _splitLocator = function (locatorString) {
   var splitLocator = locatorString.split(':');
   if (splitLocator.length === 1) {
     splitLocator[1] = splitLocator[0];
@@ -17,71 +22,68 @@ var splitLocator = function (locatorString) {
   };
   return locator;
 };
-module.exports.by = _by;
+module.exports.normify = _normify;
 module.exports.addGenericMethods = function generics(nemo) {
+  var normify = function (locator) {
+    return _normify(nemo, locator);
+  };
   var drivex = Drivex(nemo.driver, nemo.wd);
-  nemo.view._find = function (locatorString) {
-    return drivex.find(_by(nemo, splitLocator(locatorString)));
+
+  nemo.view._find = function (locator) {
+    return drivex.find(normify(locator));
   };
-  nemo.view._finds = function (locatorString) {
-    return drivex.finds(_by(nemo, splitLocator(locatorString)));
+  nemo.view._finds = function (locator) {
+    return drivex.finds(normify(locator));
   };
-  nemo.view._present = function (locatorString) {
-    return drivex.present(_by(nemo, splitLocator(locatorString)));
+  nemo.view._present = function (locator) {
+    return drivex.present(normify(locator));
   };
-  nemo.view._visible = function (locatorString) {
-    return drivex.visible(_by(nemo, splitLocator(locatorString)));
+  nemo.view._visible = function (locator) {
+    return drivex.visible(normify(locator));
   };
-  nemo.view._wait = function (locatorString, timeout) {
-    return drivex.waitForElementPromise(_by(nemo, splitLocator(locatorString)), timeout);
+  nemo.view._wait = function (locator, timeout) {
+    return drivex.waitForElementPromise(normify(locator), timeout);
   };
-  nemo.view._waitVisible = function (locatorString, timeout) {
-    var loc = _by(nemo, splitLocator(locatorString));
-    return drivex.waitForElementVisiblePromise(loc, timeout || 5000);
+  nemo.view._waitVisible = function (locator, timeout) {
+    return drivex.waitForElementVisiblePromise(normify(locator), timeout || 5000);
   };
   nemo.view._firstVisible = function (_locatorObject, timeout) {
     //transform _locatorObject to use native selenium-webdriver Locator format
     var locatorObject = _.transform(_locatorObject, function(result, n, key) {
-      result[key] = _by(nemo, splitLocator(_locatorObject[key]));
+      result[key] = normify(_locatorObject[key]);
     });
     return drivex.firstVisible(locatorObject, timeout);
   };
 
 };
-module.exports.addStarMethods = function locreator(nemo, locatorId, locatorJSON, parentWebElement) {
-  if (locatorJSON.locator === undefined || locatorJSON.type === undefined) {
-    throw new Error('[nemo-drivex] malformed locator');
-  }
+module.exports.addStarMethods = function locreator(nemo, locatorId, _locator, parentWebElement) {
   var locatorObject = {};
   var drivex = Drivex(nemo.driver, nemo.wd);
-
-  function by(locator) {
-    return _by(nemo, locator);
-  }
+  var locator = _normify(nemo, _locator);
 
   locatorObject[locatorId] = function () {
-    return drivex.find(by(locatorJSON), parentWebElement);
+    return drivex.find(locator, parentWebElement);
   };
   locatorObject[locatorId + 'By'] = function () {
-    return by(locatorJSON);
+    return locator;
   };
   locatorObject[locatorId + 'Present'] = function () {
-    return drivex.present(by(locatorJSON), parentWebElement);
+    return drivex.present(locator, parentWebElement);
   };
   locatorObject[locatorId + 'Wait'] = function (timeout, msg) {
-    return drivex.waitForElementPromise(by(locatorJSON), timeout || 5000, msg);
+    return drivex.waitForElementPromise(locator, timeout || 5000, msg);
   };
   locatorObject[locatorId + 'WaitVisible'] = function (timeout, msg) {
-    return drivex.waitForElementVisiblePromise(by(locatorJSON), timeout || 5000, msg);
+    return drivex.waitForElementVisiblePromise(locator, timeout || 5000, msg);
   };
   locatorObject[locatorId + 'Visible'] = function () {
-    return drivex.visible(by(locatorJSON), parentWebElement);
+    return drivex.visible(locator, parentWebElement);
   };
   locatorObject[locatorId + 'OptionText'] = function (optionText) {
-    return drivex.selectByOptionText(by(locatorJSON), optionText, parentWebElement);
+    return drivex.selectByOptionText(locator, optionText, parentWebElement);
   };
   locatorObject[locatorId + 'OptionValue'] = function (optionValue) {
-    return drivex.selectByOptionValue(by(locatorJSON), optionValue, parentWebElement);
+    return drivex.selectByOptionValue(locator, optionValue, parentWebElement);
   };
   return locatorObject;
 };

--- a/lib/locreator.js
+++ b/lib/locreator.js
@@ -1,31 +1,11 @@
 'use strict';
 var Drivex = require('selenium-drivex');
 var _ = require('lodash');
+var normalize = require('./normalize');
 
-var _normify = function (nemo, _locator) {
-  var locator = _locator;
-  if (_locator.constructor === String) {
-    locator = _splitLocator(_locator);
-  }
-  return nemo.wd.By[locator.type](locator.locator);
-};
-
-var _splitLocator = function (locatorString) {
-  var splitLocator = locatorString.split(':');
-  if (splitLocator.length === 1) {
-    splitLocator[1] = splitLocator[0];
-    splitLocator[0] = 'css';
-  }
-  var locator = {
-    'type': splitLocator[0],
-    'locator': splitLocator[1]
-  };
-  return locator;
-};
-module.exports.normify = _normify;
 module.exports.addGenericMethods = function generics(nemo) {
   var normify = function (locator) {
-    return _normify(nemo, locator);
+    return normalize(nemo, locator);
   };
   var drivex = Drivex(nemo.driver, nemo.wd);
 
@@ -59,7 +39,7 @@ module.exports.addGenericMethods = function generics(nemo) {
 module.exports.addStarMethods = function locreator(nemo, locatorId, _locator, parentWebElement) {
   var locatorObject = {};
   var drivex = Drivex(nemo.driver, nemo.wd);
-  var locator = _normify(nemo, _locator);
+  var locator = normalize(nemo, _locator);
 
   locatorObject[locatorId] = function () {
     return drivex.find(locator, parentWebElement);

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ *
+ * @param locatorString string defining a WebElement locator as defined in this module's README
+ * @returns Object {{type: *, locator: *}}
+ * @private
+ */
+var _splitLocator = function (locatorString) {
+  var splitLocator = locatorString.split(':');
+  if (splitLocator.length === 1) {
+    splitLocator[1] = splitLocator[0];
+    splitLocator[0] = 'css';
+  }
+  var locator = {
+    'type': splitLocator[0],
+    'locator': splitLocator[1]
+  };
+  return locator;
+};
+
+/**
+ * normalizes either string or object locator definition to a selenium Locator object
+ * @param nemo
+ * @param _locator {String or Object}
+ * @returns Locator
+ */
+module.exports = function normalize(nemo, _locator) {
+  var locator = _locator;
+  if (_locator.constructor === String) {
+    locator = _splitLocator(_locator);
+  }
+  return nemo.wd.By[locator.type](locator.locator);
+};

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -6,17 +6,21 @@
  * @returns Object {{type: *, locator: *}}
  * @private
  */
-var _splitLocator = function (locatorString) {
-  var splitLocator = locatorString.split(':');
-  if (splitLocator.length === 1) {
-    splitLocator[1] = splitLocator[0];
-    splitLocator[0] = 'css';
+var _splitLocator = function (nemo, locatorString) {
+  var strategy = locatorString.substr(0, locatorString.indexOf(':'));
+  var locator = '';
+  if (strategy.length > 0 && nemo.wd.By[strategy] !== undefined) {
+    locator = locatorString.substr(locatorString.indexOf(':') + 1, locatorString.length);
+  } else {
+    strategy = 'css';
+    locator = locatorString;
   }
-  var locator = {
-    'type': splitLocator[0],
-    'locator': splitLocator[1]
+
+  var jsonLocator = {
+    'type': strategy,
+    'locator': locator
   };
-  return locator;
+  return jsonLocator;
 };
 
 /**
@@ -28,7 +32,7 @@ var _splitLocator = function (locatorString) {
 module.exports = function normalize(nemo, _locator) {
   var locator = _locator;
   if (_locator.constructor === String) {
-    locator = _splitLocator(_locator);
+    locator = _splitLocator(nemo, _locator);
   }
   return nemo.wd.By[locator.type](locator.locator);
 };

--- a/lib/view.js
+++ b/lib/view.js
@@ -24,38 +24,16 @@
  isPresent (all viewJSON: e.g. isSubmitButtonPresent)
  instantiate any subviews
  */
-var locreator = require('./locreator');
-var normalize = require('./normalize');
-var Drivex = require('selenium-drivex');
-var Locatex = require('./locatex');
 var _ = require('lodash');
 
-
-module.exports = function View(nemo, viewJSON) {
-  var locatex = Locatex(nemo),
-    drivex = Drivex(nemo.driver),
-    viewObject = {};
-  Object.keys(viewJSON).forEach(function (locatorId) {
-    var locator = locatex(viewJSON, [locatorId]);
-
+module.exports = function View(nemo, locreator, viewJSON) {
+  return _.transform(viewJSON, function (_viewObject, n, locatorId) {
+    var locator = locreator.locatex(viewJSON, [locatorId]);
     if (viewJSON[locatorId].Elements) {
-      viewObject[locatorId] = function () { //give back the nemo.view.viewname.list() function
-        return drivex.finds(normalize(nemo, locator)).then(function (parentWebElements) {
-          return nemo.wd.promise.map(parentWebElements, function (parentWebElement) {
-            var parentObject = {};
-            Object.keys(viewJSON[locatorId].Elements).forEach(function (childLocatorId) {
-              var childLocator = locatex(viewJSON, [locatorId, 'Elements', childLocatorId]);
-              var locreated = locreator.addStarMethods(nemo, childLocatorId, childLocator, parentWebElement);
-              _.merge(parentObject, locreated);
-            });
-            return parentObject;
-          });
-        });
-      };
+      _viewObject[locatorId] = locreator.addGroup(viewJSON, locator, locatorId);
     } else {
-      _.merge(viewObject, locreator.addStarMethods(nemo, locatorId, locator));
+      _.merge(_viewObject, locreator.addStarMethods(locatorId, locator));
     }
   });
-  return viewObject;
 };
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -25,6 +25,7 @@
  instantiate any subviews
  */
 var locreator = require('./locreator');
+var normalize = require('./normalize');
 var Drivex = require('selenium-drivex');
 var Locatex = require('./locatex');
 var _ = require('lodash');
@@ -39,7 +40,7 @@ module.exports = function View(nemo, viewJSON) {
 
     if (viewJSON[locatorId].Elements) {
       viewObject[locatorId] = function () { //give back the nemo.view.viewname.list() function
-        return drivex.finds(locreator.normify(nemo, locator)).then(function (parentWebElements) {
+        return drivex.finds(normalize(nemo, locator)).then(function (parentWebElements) {
           return nemo.wd.promise.map(parentWebElements, function (parentWebElement) {
             var parentObject = {};
             Object.keys(viewJSON[locatorId].Elements).forEach(function (childLocatorId) {

--- a/lib/view.js
+++ b/lib/view.js
@@ -35,16 +35,16 @@ module.exports = function View(nemo, viewJSON) {
     drivex = Drivex(nemo.driver),
     viewObject = {};
   Object.keys(viewJSON).forEach(function (locatorId) {
-    var locatorJSON = locatex(viewJSON, [locatorId]);
+    var locator = locatex(viewJSON, [locatorId]);
 
     if (viewJSON[locatorId].Elements) {
       viewObject[locatorId] = function () { //give back the nemo.view.viewname.list() function
-        return drivex.finds(locreator.by(nemo, locatorJSON)).then(function (parentWebElements) {
+        return drivex.finds(locreator.normify(nemo, locator)).then(function (parentWebElements) {
           return nemo.wd.promise.map(parentWebElements, function (parentWebElement) {
             var parentObject = {};
             Object.keys(viewJSON[locatorId].Elements).forEach(function (childLocatorId) {
-              var childLocatorJSON = locatex(viewJSON, [locatorId, 'Elements', childLocatorId]);
-              var locreated = locreator.addStarMethods(nemo, childLocatorId, childLocatorJSON, parentWebElement);
+              var childLocator = locatex(viewJSON, [locatorId, 'Elements', childLocatorId]);
+              var locreated = locreator.addStarMethods(nemo, childLocatorId, childLocator, parentWebElement);
               _.merge(parentObject, locreated);
             });
             return parentObject;
@@ -52,7 +52,7 @@ module.exports = function View(nemo, viewJSON) {
         });
       };
     } else {
-      _.merge(viewObject, locreator.addStarMethods(nemo, locatorId, locatorJSON));
+      _.merge(viewObject, locreator.addStarMethods(nemo, locatorId, locator));
     }
   });
   return viewObject;

--- a/test/locator/formElementList.json
+++ b/test/locator/formElementList.json
@@ -3,10 +3,7 @@
 		"locator": "div.fielder",
 		"type": "css",
 		"Elements": {
-			"text": {
-				"locator": "input.texty",
-				"type": "css"
-			},
+			"text": "input.texty",
 			"button": {
 				"locator": "input[type='button']",
 				"type": "css"

--- a/test/methods.js
+++ b/test/methods.js
@@ -140,6 +140,23 @@ describe('nemo-view @methods@', function () {
       done(new Error('should not have found an element'));
     }, util.doneSuccess(done));
   });
+  it('should find an array of elements using the @_finds@positive@ method', function (done) {
+    nemo.view._finds('input[type=text]').then(function (inputs) {
+      var promises = [];
+      inputs.forEach(function (input, idx) {
+        var inputAndCheck = input.sendKeys('input', idx).then(function () {
+          return input.getAttribute('value');
+        }).then(function (value) {
+          return value;
+        });
+        promises.push(inputAndCheck);
+      });
+      return nemo.wd.promise.all(promises);
+    }).then(function (returned) {
+      assert.deepEqual(['input0', 'input1', 'input2', 'input3'], returned);
+      done();
+    }, util.doneError(done));
+  });
   it('should find an existing element using the @_wait@positive@ method', function (done) {
     nemo.view._wait('body', 3000).getTagName().then(function (tn) {
       if (tn.toLowerCase() === 'body') {

--- a/test/methods.js
+++ b/test/methods.js
@@ -126,6 +126,20 @@ describe('nemo-view @methods@', function () {
   });
 
   //GENERIC methods
+  it('should find an existing element using the @_find@positive@ method', function (done) {
+    nemo.view._find('body').getTagName().then(function (tn) {
+      if (tn.toLowerCase() === 'body') {
+        done();
+      } else {
+        done(new Error('something went wrong here'));
+      }
+    }, util.doneError(done));
+  });
+  it('should throw error for non-present element with @_find@negative@ method', function (done) {
+    nemo.view._find('booody').then(function () {
+      done(new Error('should not have found an element'));
+    }, util.doneSuccess(done));
+  });
   it('should find an existing element using the @_wait@positive@ method', function (done) {
     nemo.view._wait('body', 3000).getTagName().then(function (tn) {
       if (tn.toLowerCase() === 'body') {

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -1,0 +1,45 @@
+/* global describe,before,after,beforeEach,it */
+'use strict';
+
+var Nemo = require('nemo'),
+  path = require('path'),
+  util = require(path.resolve(__dirname, 'util')),
+  normalize = require(path.resolve(__dirname, '../lib/normalize')),
+  assert = require('assert'),
+  nemo = {};
+
+describe('nemo-view @normalize@ module', function () {
+  before(function (done) {
+    nemo = Nemo(done);
+  });
+  after(function (done) {
+    nemo.driver.quit().then(done);
+  });
+
+
+  it('should correctly convert strings and objects to selenium-webdriver locator functions', function (done) {
+    var verifications = [{
+      'input': {
+        type: 'xpath',
+        locator: '/x/y/z:[abc]'
+      },
+      'output': nemo.wd.By['xpath']('/x/y/z:[abc]')
+    }, {
+      'input': 'xpath:/x/y/z:[abc]',
+      'output': nemo.wd.By['xpath']('/x/y/z:[abc]')
+
+    }, {
+      'input': 'a span[class=foo]:nth-child',
+      'output': nemo.wd.By['css']('a span[class=foo]:nth-child')
+
+    }, {
+      'input': 'css:a span[class=foo]:nth-child',
+      'output': nemo.wd.By['css']('a span[class=foo]:nth-child')
+
+    }];
+    verifications.forEach(function (verification) {
+      assert.deepEqual(verification.output, normalize(nemo, verification.input));
+    });
+    done();
+  });
+});

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -1,9 +1,8 @@
-/* global describe,before,after,beforeEach,it */
+/* global describe,before,after,it */
 'use strict';
 
 var Nemo = require('nemo'),
   path = require('path'),
-  util = require(path.resolve(__dirname, 'util')),
   normalize = require(path.resolve(__dirname, '../lib/normalize')),
   assert = require('assert'),
   nemo = {};
@@ -23,18 +22,18 @@ describe('nemo-view @normalize@ module', function () {
         type: 'xpath',
         locator: '/x/y/z:[abc]'
       },
-      'output': nemo.wd.By['xpath']('/x/y/z:[abc]')
+      'output': nemo.wd.By.xpath('/x/y/z:[abc]')
     }, {
       'input': 'xpath:/x/y/z:[abc]',
-      'output': nemo.wd.By['xpath']('/x/y/z:[abc]')
+      'output': nemo.wd.By.xpath('/x/y/z:[abc]')
 
     }, {
       'input': 'a span[class=foo]:nth-child',
-      'output': nemo.wd.By['css']('a span[class=foo]:nth-child')
+      'output': nemo.wd.By.css('a span[class=foo]:nth-child')
 
     }, {
       'input': 'css:a span[class=foo]:nth-child',
-      'output': nemo.wd.By['css']('a span[class=foo]:nth-child')
+      'output': nemo.wd.By.css('a span[class=foo]:nth-child')
 
     }];
     verifications.forEach(function (verification) {

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -8,7 +8,7 @@ module.exports.waitForJSReady = function waitForJSReady(nemo) {
         return false;
       });
     }
-    , 10000, 'JavaScript didn\'t load');
+    , 15000, 'JavaScript didn\'t load');
 };
 
 module.exports.doneSuccess = function (done) {

--- a/util/index.js
+++ b/util/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports.once = function once(fn) {
+  var called = false;
+  return function (err) {
+    if (!!called) {
+      return undefined;
+    }
+    called = true;
+    return fn(err);
+  };
+};


### PR DESCRIPTION
This allows the locators to either underscore methods or JSON view methods to be of both string or Object types. Please see updated README.

Also, Cleaning up `locreator` some more. Moving out the last method to `selenium-drivex`. Move normalize functionality to separate module