### PR TITLE
Normalize fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,13 +260,13 @@ The following generic methods are added to `nemo.view`
 
 `@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
-`@returns {Promise}` resolves to true or rejected
+`@returns {Promise}` resolves to true or false
 
 #### _visible(locatorString)
 
 `@argument locatorDefinition {String|Object}` - Please see `locatorDefinition` above
 
-`@returns {Promise}` resolves to true or rejected
+`@returns {Promise}` resolves to true or false.  Rejected if element is not found
 
 #### _wait(locatorString[, timeout [, msg]])
 

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -34,15 +34,11 @@ module.exports = function normalize(nemo, _locator) {
   var locator = _locator;
   var normalizedLocator;
 
-  if (locator.using && locator.value && nemo.wd.By[locator.using]) {
-    normalizedLocator = nemo.wd.By[locator.using](locator.value);
-    if(normalizedLocator.constructor === locator.constructor){
-      return locator; //input object was a normalized locator.  Just return it back
-    } else {
-      return normalizedLocator;
-    }
+  //get a hold of webdriver.Locator.  It's the same for all strategies.
+  var Locator = nemo.wd.By.id('xyz').constructor;
+  if (locator instanceof Locator) {
+    return locator; //already normalized
   }
-
   if (locator.constructor !== String) {
     if (!locator.locator || !locator.locator.trim()) {
       throw new Error('NO or EMPTY locator found, please fix it');

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -25,6 +25,7 @@ var _splitLocator = function (nemo, locatorString) {
 
 /**
  * normalizes either string or object locator definition to a selenium Locator object
+ * if input object is already a selenium Locator then the same object is returned
  * @param nemo
  * @param _locator {String or Object}
  * @returns Locator
@@ -32,6 +33,16 @@ var _splitLocator = function (nemo, locatorString) {
 module.exports = function normalize(nemo, _locator) {
   var locator = _locator;
   var normalizedLocator;
+
+  if (locator.using && locator.value && nemo.wd.By[locator.using]) {
+    normalizedLocator = nemo.wd.By[locator.using](locator.value);
+    if(normalizedLocator.constructor === locator.constructor){
+      return locator; //input object was a normalized locator.  Just return it back
+    } else {
+      return normalizedLocator;
+    }
+  }
+
   if (locator.constructor !== String) {
     if (!locator.locator || !locator.locator.trim()) {
       throw new Error('NO or EMPTY locator found, please fix it');
@@ -42,8 +53,6 @@ module.exports = function normalize(nemo, _locator) {
   }
   if (_locator.constructor === String) {
     locator = _splitLocator(nemo, _locator);
-  } else if (locator instanceof nemo.wd.By.constructor) {
-    return locator; //no need to normalize, WebDriver understands this format.
   }
   normalizedLocator = nemo.wd.By[locator.type](locator.locator);
   return normalizedLocator;

--- a/test/methods.js
+++ b/test/methods.js
@@ -161,9 +161,27 @@ describe('nemo-view @methods@', function () {
       }
     }, util.doneError(done));
   });
-  it('should resolve false if element doesn\'t exists @_present@positive@ method', function (done) {
+  it('should resolve false if element doesn\'t exists @_present@negative@ method', function (done) {
     nemo.view._present('booody').then(function (found) {
       if (!found) {
+        done();
+      } else {
+        done(new Error('something went wrong here'));
+      }
+    }, util.doneError(done));
+  });
+  it('should resolve true if element visible @_visible@positive@ method', function (done) {
+    nemo.view._visible('body').then(function (visible) {
+      if (visible) {
+        done();
+      } else {
+        done(new Error('something went wrong here'));
+      }
+    }, util.doneError(done));
+  });
+  it('should resolve false if element not visible @_visible@negative@ method', function (done) {
+    nemo.view._visible('id:outy').then(function (visible) {
+      if (!visible) {
         done();
       } else {
         done(new Error('something went wrong here'));

--- a/test/methods.js
+++ b/test/methods.js
@@ -152,6 +152,24 @@ describe('nemo-view @methods@', function () {
     });
   });
   //GENERIC methods
+  it('should resolve true if element exists @_present@positive@ method', function (done) {
+    nemo.view._present('body').then(function (found) {
+      if (found) {
+        done();
+      } else {
+        done(new Error('something went wrong here'));
+      }
+    }, util.doneError(done));
+  });
+  it('should resolve false if element doesn\'t exists @_present@positive@ method', function (done) {
+    nemo.view._present('booody').then(function (found) {
+      if (!found) {
+        done();
+      } else {
+        done(new Error('something went wrong here'));
+      }
+    }, util.doneError(done));
+  });
   it('should find an existing element using the @_find@positive@ method', function (done) {
     nemo.view._find('body').getTagName().then(function (tn) {
       if (tn.toLowerCase() === 'body') {

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -22,10 +22,7 @@ describe('nemo-view @normalize@ module', function () {
         type: 'xpath',
         locator: '/x/y/z:[abc]'
       },
-      'output': {
-        type: 'xpath',
-        locator: '/x/y/z:[abc]'
-      }
+      'output': { using: 'xpath', value: '/x/y/z:[abc]' }
     },
       {
       'input': 'xpath:/x/y/z:[abc]',
@@ -45,6 +42,14 @@ describe('nemo-view @normalize@ module', function () {
     });
     done();
   });
+
+  it('should return unmodified input object if it is already a locator', function (done) {
+    var inputLocator = nemo.wd.By.id('xyz');
+    var outputLocator = normalize(nemo, inputLocator);
+    assert(inputLocator === outputLocator, 'expected output locator to be the input object');
+    done();
+  });
+
   it('should correctly throw error @notype@', function (done) {
     var noType = {
       "noType": {

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -21,24 +21,20 @@ describe('nemo-view @normalize@ module', function () {
         Locator = nemo.wd.By.id('xyz').constructor,
         verifications = [
       {
-        by: 'xpath',
         input: {
           type: 'xpath',
           locator: '/x/y/z:[abc]'
         },
         output: { using: 'xpath', value: '/x/y/z:[abc]' }
       }, {
-        by: 'xpath',
         input: 'xpath:/x/y/z:[abc]',
         output: nemo.wd.By.xpath('/x/y/z:[abc]')
 
       }, {
-        by: 'css',
         input: 'a span[class=foo]:nth-child',
         output: nemo.wd.By.css('a span[class=foo]:nth-child')
 
       }, {
-        by: 'css',
         input: 'css:a span[class=foo]:nth-child',
         output: nemo.wd.By.css('a span[class=foo]:nth-child')
       }

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -17,33 +17,35 @@ describe('nemo-view @normalize@ module', function () {
 
 
   it('should correctly convert strings and objects to selenium-webdriver locator functions', function (done) {
-    var verifications = [{
-      'input': {
-        type: 'xpath',
-        locator: '/x/y/z:[abc]'
+    var verifications = [
+      {
+        'input': {
+          type: 'xpath',
+          locator: '/x/y/z:[abc]'
+        },
+        'output': { using: 'xpath', value: '/x/y/z:[abc]' }
       },
-      'output': { using: 'xpath', value: '/x/y/z:[abc]' }
-    },
       {
         'input': {
           using: 'id',
           value: 'xyz'
-      },
+        },
         'output': nemo.wd.By.id('xyz')
-    },
+      },
       {
-      'input': 'xpath:/x/y/z:[abc]',
-      'output': nemo.wd.By.xpath('/x/y/z:[abc]')
+        'input': 'xpath:/x/y/z:[abc]',
+        'output': nemo.wd.By.xpath('/x/y/z:[abc]')
 
-    }, {
-      'input': 'a span[class=foo]:nth-child',
-      'output': nemo.wd.By.css('a span[class=foo]:nth-child')
+      }, {
+        'input': 'a span[class=foo]:nth-child',
+        'output': nemo.wd.By.css('a span[class=foo]:nth-child')
 
-    }, {
-      'input': 'css:a span[class=foo]:nth-child',
-      'output': nemo.wd.By.css('a span[class=foo]:nth-child')
+      }, {
+        'input': 'css:a span[class=foo]:nth-child',
+        'output': nemo.wd.By.css('a span[class=foo]:nth-child')
 
-    }];
+      }
+    ];
     verifications.forEach(function (verification) {
       assert.deepEqual(verification.output, normalize(nemo, verification.input));
     });

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -17,37 +17,36 @@ describe('nemo-view @normalize@ module', function () {
 
 
   it('should correctly convert strings and objects to selenium-webdriver locator functions', function (done) {
-    var verifications = [
+    var output,
+        Locator = nemo.wd.By.id('xyz').constructor,
+        verifications = [
       {
-        'input': {
+        by: 'xpath',
+        input: {
           type: 'xpath',
           locator: '/x/y/z:[abc]'
         },
-        'output': { using: 'xpath', value: '/x/y/z:[abc]' }
-      },
-      {
-        'input': {
-          using: 'id',
-          value: 'xyz'
-        },
-        'output': nemo.wd.By.id('xyz')
-      },
-      {
-        'input': 'xpath:/x/y/z:[abc]',
-        'output': nemo.wd.By.xpath('/x/y/z:[abc]')
+        output: { using: 'xpath', value: '/x/y/z:[abc]' }
+      }, {
+        by: 'xpath',
+        input: 'xpath:/x/y/z:[abc]',
+        output: nemo.wd.By.xpath('/x/y/z:[abc]')
 
       }, {
-        'input': 'a span[class=foo]:nth-child',
-        'output': nemo.wd.By.css('a span[class=foo]:nth-child')
+        by: 'css',
+        input: 'a span[class=foo]:nth-child',
+        output: nemo.wd.By.css('a span[class=foo]:nth-child')
 
       }, {
-        'input': 'css:a span[class=foo]:nth-child',
-        'output': nemo.wd.By.css('a span[class=foo]:nth-child')
-
+        by: 'css',
+        input: 'css:a span[class=foo]:nth-child',
+        output: nemo.wd.By.css('a span[class=foo]:nth-child')
       }
     ];
     verifications.forEach(function (verification) {
-      assert.deepEqual(verification.output, normalize(nemo, verification.input));
+      output = normalize(nemo, verification.input);
+      assert.deepEqual(verification.output, output);
+      assert(output instanceof Locator, 'Expected normalized locator to be an instance of Locator');
     });
     done();
   });

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -25,6 +25,13 @@ describe('nemo-view @normalize@ module', function () {
       'output': { using: 'xpath', value: '/x/y/z:[abc]' }
     },
       {
+        'input': {
+          using: 'id',
+          value: 'xyz'
+      },
+        'output': nemo.wd.By.id('xyz')
+    },
+      {
       'input': 'xpath:/x/y/z:[abc]',
       'output': nemo.wd.By.xpath('/x/y/z:[abc]')
 


### PR DESCRIPTION
1. normalize did not properly process an already normalized input.  The `instanceof nemo.wd.By.constructor` check does produced unexpected results such as:

  `{} instanceof nemo.wd.By.constructor` is `true` 
  `nemo.wd.By.id("xyz") instanceof nemo.wd.By.constructor` is `false`.  
  This was causing errors when passing `By` results into other functions like `_find`.

  I could not find easy access to `webdriver.Locator` constructor, so ended up calling the `By` function inside `normalize` to compare against the input locator.

  Unit tests were added and/or fixed in relation to above fix.

2. Added some `_visible` and `_present` tests
3. Some minor readme fixes for `_visible` and `_present`