### PR TITLE
Clarify locator methods' documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,14 +400,14 @@ Other than that, the nemo-view uses nemo-locatex internally, so if you change yo
 
 * arguments
   * value: the expected value for the element
-* returns: Promise which resolves to true when the expected text matches
+* returns: Promise which resolves to true when the expected text matches, or rejects when it doesn't
 
 #### [locatorName]AttrEquals
 
 * arguments
   * attribute: attribute value to check
   * value: the expected value for the element
-* returns: Promise which resolves to true when the expected text matches
+* returns: Promise which resolves to true when the expected text matches, or rejects when it doesn't
 
 ## Using locator specialization
 


### PR DESCRIPTION
The documentation for `[locatorName]TextEquals` and `[locatorName]AttrEquals` was unclear about what happens when the text/attr is not equal to the expected value: does it resolve to `false` or reject? This commit clarifies that the Promise rejects in these scenarios.