### PR TITLE
fix(error): make identifying locators in errors easier

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function addView(nemo, locreator) {
     //default hang to true
 
 
-    var _view = View(nemo, locreator, json);
+    var _view = View(nemo, locreator, json, viewNSArray);
 
     viewNS[viewNSArray[viewNSArray.length - 1]] = _view;
     return _view;

--- a/lib/locreator.js
+++ b/lib/locreator.js
@@ -45,8 +45,9 @@ class Locreator {
             return drivex.firstVisible(locatorObject, timeout);
         };
     }
-    addStarMethods(locatorId, locatorJSON, parentWebElement) {
+    addStarMethods(locatorId, locatorJSON, viewNSArray = [], parentWebElement) {
         log('add star methods for %s', locatorId);
+        const fullLocatorId = _.concat(viewNSArray, locatorId).join('/');
         let locatorObject = {};
         const drivex = this.drivex;
         let locreator = this;
@@ -61,9 +62,9 @@ class Locreator {
 
         locatorObject[locatorId + 'Present'] = locatorObject[locatorId].present = () => drivex.present(locator(), parentWebElement);
 
-        locatorObject[locatorId + 'Wait'] = locatorObject[locatorId].wait = (timeout, msg) => drivex.waitForElementPromise(locator(), timeout || 5000, msg || 'Wait failed for locator [' + locatorId + ']');
+        locatorObject[locatorId + 'Wait'] = locatorObject[locatorId].wait = (timeout, msg) => drivex.waitForElementPromise(locator(), timeout || 5000, msg || 'Wait failed for locator [' + fullLocatorId + ']');
 
-        locatorObject[locatorId + 'WaitVisible'] = locatorObject[locatorId].waitVisible = (timeout, msg) => drivex.waitForElementVisiblePromise(locator(), timeout || 5000, msg || 'WaitVisible failed for locator [' + locatorId + ']');
+        locatorObject[locatorId + 'WaitVisible'] = locatorObject[locatorId].waitVisible = (timeout, msg) => drivex.waitForElementVisiblePromise(locator(), timeout || 5000, msg || 'WaitVisible failed for locator [' + fullLocatorId + ']');
 
         locatorObject[locatorId + 'Visible'] = locatorObject[locatorId].visible = () => drivex.visible(locator(), parentWebElement);
 
@@ -77,7 +78,7 @@ class Locreator {
 
         return locatorObject;
     }
-    addGroup(locatorJSON) {
+    addGroup(locatorJSON, viewNSArray) {
         const nemo = this.nemo;
         const drivex = this.drivex;
         let locreator = this;
@@ -88,7 +89,7 @@ class Locreator {
                     let parentObject = {};
                     Object.keys(localizedJSON.Elements).forEach((childLocatorId) => {
                         const childLocatorJSON = localizedJSON.Elements[childLocatorId];
-                        const starMethods = locreator.addStarMethods(childLocatorId, childLocatorJSON, parentWebElement);
+                        const starMethods = locreator.addStarMethods(childLocatorId, childLocatorJSON, viewNSArray, parentWebElement);
                         _.merge(parentObject, starMethods);
                     });
                     return parentObject;

--- a/lib/view.js
+++ b/lib/view.js
@@ -26,13 +26,13 @@
  */
 const _ = require('lodash');
 
-module.exports = function View(nemo, locreator, viewJSON) {
+module.exports = function View(nemo, locreator, viewJSON, viewNSArray) {
   return _.transform(viewJSON,  (_viewObject, n, locatorId) => {
     const locatorJSON = viewJSON[locatorId];
     if (locreator.locatex(locatorJSON).Elements) {
-      _viewObject[locatorId] = locreator.addGroup(locatorJSON);
+      _viewObject[locatorId] = locreator.addGroup(locatorJSON, viewNSArray);
     } else {
-      _.merge(_viewObject, locreator.addStarMethods(locatorId, locatorJSON));
+      _.merge(_viewObject, locreator.addStarMethods(locatorId, locatorJSON, viewNSArray));
     }
   });
 };


### PR DESCRIPTION
# Background
Generally there are two concerns while naming locators:
1. a locator name should be unique because when a `locatorWait()` times out, the error prints only the locator name, which should thus be sufficient to identify the locator that was not found
1. locators need to be grouped into directories in a large app

# Problem
Thus usually you end up with directories to group locator files, such as `flowA/` and `flowB/`, each containing a `successPage.json`, each of which contains a list of locators, all of which are prefixed with the unnecessary `flowXSuccessPage`, just so that errors can pinpoint the specific `header` that was not found.

This makes accessing locators in tests verbose as well:
`nemo.view.flowA.successPage.flowASuccessPageHeader`
`nemo.view.flowB.successPage.flowBSuccessPageHeader`

# Solution
This PR aims to simplify such verbose naming practices by picking up the path of the locator automatically. With this, devs will be able to use a simpler, non-repetitive access syntax:
`nemo.view.flowA.successPage.header`
`nemo.view.flowB.successPage.header`

# Impact
It won't have any negative impact on existing projects. The only change for existing projects will be that errors will change thus:
from `Wait failed for locator [flowASuccessPageHeader]`
to `Wait failed for locator [flowA/successPage/flowASuccessPageHeader]`

If existing projects so desire, they can make their locator directory (c)leaner to get the final error message to be: `Wait failed for locator [flowA/successPage/header]`