### PR TITLE
Adding a global default timeout for all wait functions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,22 +53,31 @@ function addView(nemo, locreator) {
     return _view;
   };
 }
-module.exports.setup = function (_locatorDirectory, _nemo, __callback) {
+module.exports.setup = function (_locatorDirectory, _defaultTimeout, _nemo, __callback) {
   log('plugin setup is called');
 
   //normalize arguments
   var nemo = _nemo;
   var locatorDirectory = _locatorDirectory;
+  var defaultTimeout = _defaultTimeout;
   var _callback = __callback;
+
   if (arguments.length === 2) {
     locatorDirectory = null;
+    defaultTimeout = 5000;
     nemo = arguments[0];
     _callback = arguments[1];
+  } else if (arguments.length === 3) {
+    defaultTimeout = 5000;
+    nemo = arguments[1];
+    _callback = arguments[2];
   }
+
   var callback = util.once(_callback);
 
   //add view namespace
   nemo.view = {};
+  nemo.view.defaultTimeout = defaultTimeout;
 
   //instantiate locreator
   var locreator = new Locreator(nemo);

--- a/lib/locreator.js
+++ b/lib/locreator.js
@@ -29,9 +29,9 @@ class Locreator {
 
         nemo.view._visible = (locator, parentElement) => drivex.visible(normify(locator), parentElement);
 
-        nemo.view._wait = (locator, timeout, msg) => drivex.waitForElementPromise(normify(locator), timeout, msg);
+        nemo.view._wait = (locator, timeout, msg) => drivex.waitForElementPromise(normify(locator), timeout || nemo.view.defaultTimeout, msg);
 
-        nemo.view._waitVisible = (locator, timeout, msg) => drivex.waitForElementVisiblePromise(normify(locator), timeout || 5000, msg);
+        nemo.view._waitVisible = (locator, timeout, msg) => drivex.waitForElementVisiblePromise(normify(locator), timeout || nemo.view.defaultTimeout, msg);
 
         nemo.view._optionText =  (locator, optionText, parentElement) =>  drivex.selectByOptionText(normify(locator), optionText, parentElement);
 
@@ -51,6 +51,7 @@ class Locreator {
         const drivex = this.drivex;
         let locreator = this;
         const locator =  () => locreator.normify(locreator.locatex(locatorJSON));
+        let nemo = this.nemo;
 
         //this is an error check. if an error thrown, invalid locatorJSON.
         locator();
@@ -61,9 +62,9 @@ class Locreator {
 
         locatorObject[locatorId + 'Present'] = locatorObject[locatorId].present = () => drivex.present(locator(), parentWebElement);
 
-        locatorObject[locatorId + 'Wait'] = locatorObject[locatorId].wait = (timeout, msg) => drivex.waitForElementPromise(locator(), timeout || 5000, msg || 'Wait failed for locator [' + locatorId + ']');
+        locatorObject[locatorId + 'Wait'] = locatorObject[locatorId].wait = (timeout, msg) => drivex.waitForElementPromise(locator(), timeout || nemo.view.defaultTimeout, msg || 'Wait failed for locator [' + locatorId + ']');
 
-        locatorObject[locatorId + 'WaitVisible'] = locatorObject[locatorId].waitVisible = (timeout, msg) => drivex.waitForElementVisiblePromise(locator(), timeout || 5000, msg || 'WaitVisible failed for locator [' + locatorId + ']');
+        locatorObject[locatorId + 'WaitVisible'] = locatorObject[locatorId].waitVisible = (timeout, msg) => drivex.waitForElementVisiblePromise(locator(), timeout || nemo.view.defaultTimeout, msg || 'WaitVisible failed for locator [' + locatorId + ']');
 
         locatorObject[locatorId + 'Visible'] = locatorObject[locatorId].visible = () => drivex.visible(locator(), parentWebElement);
 


### PR DESCRIPTION
This PR is Addressing Issue #81. 
Adding nemo.view.defaultTimeout as a new name space for Nemo-view. 

**Usage:** 
Add global waitTimeout on config.json:
```
  "plugins": {
    "view": {
      "module": "nemo-view",
      "arguments": [ "path:../../node_modules/gctnightswatchnodeweb/locator", 30000]
    },
```
If no timeout value provided to the plugin arguments, Nemo-view will use the fallback timeout, which is 5000. Just like before
```
  "plugins": {
    "view": {
      "module": "nemo-view",
      "arguments": [ "path:../../node_modules/gctnightswatchnodeweb/locator"]
    },
```

Another way to use it, set timeout for the case: 
`nemo.view.defaultTimeout = 60000;
`